### PR TITLE
xyzc override

### DIFF
--- a/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeDialog.java
+++ b/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeDialog.java
@@ -50,6 +50,7 @@
 package org.knime.knip.ilastik.nodes.headless;
 
 import org.knime.core.node.defaultnodesettings.DefaultNodeSettingsPane;
+import org.knime.core.node.defaultnodesettings.DialogComponentBoolean;
 import org.knime.core.node.defaultnodesettings.DialogComponentColumnNameSelection;
 import org.knime.core.node.defaultnodesettings.DialogComponentFileChooser;
 import org.knime.core.node.defaultnodesettings.DialogComponentNumber;
@@ -81,7 +82,6 @@ public class IlastikHeadlessNodeDialog extends DefaultNodeSettingsPane {
         createNewGroup("Path to Ilastik Project File");
         addDialogComponent(new DialogComponentFileChooser(
                 IlastikHeadlessNodeModel.createPathToIlastikProjectFileModel(), "test2", ".ilp"));
-
         closeCurrentGroup();
 
         createNewGroup("Memory / CPU Limits");
@@ -89,7 +89,11 @@ public class IlastikHeadlessNodeDialog extends DefaultNodeSettingsPane {
                 "Ilastik thread count", 1));
         addDialogComponent(new DialogComponentNumber(IlastikHeadlessNodeModel.createIlastikMaxMemoryModel(),
                 "Ilastik max memory (MB)", 1));
+        closeCurrentGroup();
 
+        createNewGroup("TIFF Bugfix");
+        addDialogComponent(new DialogComponentBoolean(IlastikHeadlessNodeModel.createOutputDimensionsOverrideModel(),
+                "Override result .tiff dimensions from XYT to XYZC?"));
         closeCurrentGroup();
 
         createNewGroup("Column Selection");

--- a/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeFactory.java
+++ b/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeFactory.java
@@ -54,6 +54,7 @@ import org.knime.core.node.NodeFactory;
 import org.knime.core.node.NodeView;
 import org.knime.knip.base.nodes.view.TableCellViewNodeView;
 
+import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 
 /**
@@ -61,7 +62,7 @@ import net.imglib2.type.numeric.RealType;
  * @author Andreas Graumann, University of Konstanz
  * @param <T>
  */
-public class IlastikHeadlessNodeFactory<T extends RealType<T>> extends NodeFactory<IlastikHeadlessNodeModel<T>> {
+public class IlastikHeadlessNodeFactory<T extends RealType<T> & NativeType<T>> extends NodeFactory<IlastikHeadlessNodeModel<T>> {
 
     /**
      * {@inheritDoc}

--- a/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeFactory.xml
+++ b/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeFactory.xml
@@ -19,6 +19,7 @@
 			given in "Preferences -> KNIME -> Image Processing Plugin -> Ilastik -> Path to Ilastik installation".
 		</intro>
 		<option name="Path to Ilastik project file">The ilastik project to be executed.</option>
+		<option name="TIFF bugfix">Should the XYT output of ilastik be converted to XYZC?</option>
 		<option name="Memory / CPU limits">Maximum of memory and threads allowed for Ilastik alone.</option>
 		<option name="Column Selection">Column containing the images to be processed.</option>
 	</fullDescription>

--- a/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
+++ b/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
@@ -424,10 +424,10 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
         Thread t = new Thread() {
             @Override
             public void run() {
-                BufferedReader bis = new BufferedReader(new InputStreamReader(in, Charset.defaultCharset()));
+
                 String line;
 
-                try {
+                try (BufferedReader bis = new BufferedReader(new InputStreamReader(in, Charset.defaultCharset()))) {
                     while ((line = bis.readLine()) != null) {
                         logger.log(line);
                     }
@@ -632,6 +632,7 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
 
     static class DirectedLogServiceFactory {
         private static ErrorLogService m_errorLogService;
+
         private static DebugLogService m_debugLogService;
 
         public static ErrorLogService error() {

--- a/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
+++ b/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
@@ -384,7 +384,7 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
         inFiles.add(0, path);
         inFiles.add(1, "--headless");
         inFiles.add(2, "--project=".concat(outpath));
-        inFiles.add(3, "--output_format=multipage tiff");
+        inFiles.add(3, "--output_format=tif");
         inFiles.add(4, "--output_filename_format=".concat(tmpDirPath).concat("{nickname}_result"));
 
         KNIPGateway.log().debug("Executing ilastik with " + String.join(", ", inFiles));

--- a/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
+++ b/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
@@ -102,6 +102,7 @@ import org.knime.knip.io.nodes.imgwriter2.ImgWriter2;
 import org.scijava.log.DefaultUncaughtExceptionHandler;
 
 import net.imagej.ImgPlus;
+import net.imagej.ImgPlusMetadata;
 import net.imagej.axis.Axes;
 import net.imagej.axis.CalibratedAxis;
 import net.imagej.axis.DefaultLinearAxis;
@@ -269,11 +270,14 @@ public class IlastikHeadlessNodeModel<T extends RealType<T> & NativeType<T>> ext
             // store in-image name in list
             files.add(fileName);
 
-            // map for dimensions
-            final int[] map = new int[imgvalue.getDimensions().length];
-            for (int i = 0; i < map.length; i++) {
-                map[i] = i;
-            }
+
+            // map for dimensions ZCT. -1 means non-existent
+            final ImgPlusMetadata imgMeta = imgvalue.getMetadata();
+            final int[] map = new int[] {
+                    imgMeta.dimensionIndex(Axes.Z),
+                    imgMeta.dimensionIndex(Axes.CHANNEL),
+                    imgMeta.dimensionIndex(Axes.TIME)
+            };
 
             // Image Writer
             exec.checkCanceled();

--- a/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
+++ b/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
@@ -327,7 +327,7 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
             } catch (Exception e) {
                 imgOpener.close();
                 throw new IllegalStateException(
-                        "Can't read image in Ilastik Headless Node at RowId: " + key + " : " + e);
+                        "Can't read image in Ilastik Headless Node at RowId: " + key + " : " + e, e);
             }
         });
         imgOpener.close();
@@ -366,7 +366,7 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
             outpath = FileUtil.resolveToPath(FileUtil.toURL(m_pathToIlastikProjectFileModel.getStringValue()))
                     .toAbsolutePath().toString();
         } catch (InvalidPathException | URISyntaxException e) {
-            throw new IllegalArgumentException("The Path to the project file could not be resolved: " + e);
+            throw new IllegalArgumentException("The Path to the project file could not be resolved: " + e, e);
         }
         if (outpath == null) {
             throw new IllegalArgumentException("The Path to the project file could not be resolved.");
@@ -612,6 +612,7 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
 
     interface DirectedLogService {
         public void log(Object arg0);
+        public void log(Object arg0, Throwable arg1);
     }
 
     static class ErrorLogService implements DirectedLogService {
@@ -619,6 +620,12 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
         public void log(final Object arg0) {
             KNIPGateway.log().error(arg0);
         }
+
+        @Override
+        public void log(final Object arg0, final Throwable arg1) {
+            KNIPGateway.log().error(arg0);
+        }
+
     }
 
     static class DebugLogService implements DirectedLogService {
@@ -626,6 +633,12 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
         public void log(final Object arg0) {
             KNIPGateway.log().debug(arg0);
         }
+
+        @Override
+        public void log(final Object arg0, final Throwable arg1) {
+            KNIPGateway.log().debug(arg0);
+        }
+
     }
 
     static class DirectedLogServiceFactory {

--- a/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
+++ b/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
@@ -286,6 +286,12 @@ public class IlastikHeadlessNodeModel<T extends RealType<T> & NativeType<T>> ext
                     imgMeta.dimensionIndex(Axes.TIME)
             };
 
+            for (int i = 0; i < map.length; i++) {
+                if (map[i] != -1) {
+                    map[i] -= 2; // substract 2 as we start _behind_ XY
+                }
+            }
+
             // Image Writer
             exec.checkCanceled();
 

--- a/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
+++ b/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
@@ -57,7 +57,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.file.InvalidPathException;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -69,6 +69,7 @@ import org.knime.core.data.DataColumnSpec;
 import org.knime.core.data.DataColumnSpecCreator;
 import org.knime.core.data.DataRow;
 import org.knime.core.data.DataTableSpec;
+import org.knime.core.data.MissingCell;
 import org.knime.core.data.RowKey;
 import org.knime.core.data.container.ColumnRearranger;
 import org.knime.core.data.container.DataContainer;
@@ -85,11 +86,11 @@ import org.knime.core.node.KNIMEConstants;
 import org.knime.core.node.NodeModel;
 import org.knime.core.node.NodeSettingsRO;
 import org.knime.core.node.NodeSettingsWO;
+import org.knime.core.node.defaultnodesettings.SettingsModelBoolean;
 import org.knime.core.node.defaultnodesettings.SettingsModelInteger;
 import org.knime.core.node.defaultnodesettings.SettingsModelIntegerBounded;
 import org.knime.core.node.defaultnodesettings.SettingsModelString;
 import org.knime.core.util.FileUtil;
-import org.knime.core.util.Pair;
 import org.knime.knip.base.data.img.ImgPlusCell;
 import org.knime.knip.base.data.img.ImgPlusCellFactory;
 import org.knime.knip.base.data.img.ImgPlusValue;
@@ -101,7 +102,17 @@ import org.knime.knip.io.nodes.imgwriter2.ImgWriter2;
 import org.scijava.log.DefaultUncaughtExceptionHandler;
 
 import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.CalibratedAxis;
+import net.imagej.axis.DefaultLinearAxis;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgView;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
 
 /**
  *
@@ -110,7 +121,8 @@ import net.imglib2.type.numeric.RealType;
  * @author Andreas Graumann, University of Konstanz
  * @param <T>
  */
-public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel implements BufferedDataTableHolder {
+public class IlastikHeadlessNodeModel<T extends RealType<T> & NativeType<T>> extends NodeModel
+        implements BufferedDataTableHolder {
 
     private static final String COL_NAME = "Result";
 
@@ -142,16 +154,24 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
      * ilastik cpu / memory limits
      */
     private final SettingsModelInteger m_ilastikMaxMemory = createIlastikMaxMemoryModel();
+
     private final SettingsModelIntegerBounded m_ilastikThreadCount = createIlastikThreadCountModel();
+
+    /**
+     * tiff output dimensions override (bugfix for ilastik)
+     */
+    private final SettingsModelBoolean m_outputDimensionsOverride = createOutputDimensionsOverrideModel();
 
     /**
      * data table for table cell view
      */
     private BufferedDataTable m_data;
 
-    private Map<RowKey, Pair<String, String>> m_outFiles;
+    private Map<RowKey, String> m_outFiles; // rowKey -> out path
 
     private ImgPlusCellFactory m_imgPlusCellFactory;
+
+    private int m_inputImgColIdx;
 
     /**
      * @param nrInDataPorts
@@ -202,7 +222,8 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
             throws Exception {
 
         // get index of image column
-        int idx = getImgColIdx(inData[0].getSpec());
+        final BufferedDataTable tableIn = inData[0];
+        m_inputImgColIdx = getImgColIdx(tableIn.getSpec());
 
         // create tmp directory
         final String tmpDirPath = KNIMEConstants.getKNIMETempDir() + "/ilastik/" + UUID.randomUUID() + "/";
@@ -214,15 +235,15 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
 
         final ImgWriter2 iW = new ImgWriter2();
 
-        m_outFiles = new LinkedHashMap<>();
+        m_outFiles = new HashMap<>();
         m_imgPlusCellFactory = new ImgPlusCellFactory(exec);
 
         int uniqueFileNameCounter = 0;
 
         // iterate over all input images and copy them to the tmp directory
-        for (DataRow row : inData[0]) {
+        for (DataRow row : tableIn) {
 
-            final DataCell cell = row.getCell(idx);
+            final DataCell cell = row.getCell(m_inputImgColIdx);
 
             if (cell.isMissing()) {
                 KNIPGateway.log().warn("Ignoring missing cell in row " + row.getKey() + "!");
@@ -240,7 +261,7 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
             // store in map
             String resultFileName = fileName + "_result.tif";
 
-            m_outFiles.put(row.getKey(), new Pair<>(resultFileName, imgvalue.getImgPlus().getSource()));
+            m_outFiles.put(row.getKey(), resultFileName);
 
             // attach file extension
             fileName = fileName + ".tif";
@@ -270,22 +291,22 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
             if (colCreationMode.equals(ColCreationModes.NEW_TABLE)) { // new table
 
                 BufferedDataContainer container = exec.createDataContainer(createImgSpec());
-                readResultImages(new ImgPlusCellFactory(exec), container);
+                readResultImages(tableIn, container);
                 container.close();
                 m_data = container.getTable();
             } else if (colCreationMode.equals(ColCreationModes.APPEND)) { // Append
-                final ColumnRearranger rearranger = new ColumnRearranger(inData[0].getSpec());
+                final ColumnRearranger rearranger = new ColumnRearranger(tableIn.getSpec());
                 final DataColumnSpec newColSpec = new DataColumnSpecCreator(COL_NAME, ImgPlusCell.TYPE).createSpec();
                 final IlastikCellFactory fac = createResultCellFactory(newColSpec);
                 rearranger.append(fac);
-                m_data = exec.createColumnRearrangeTable(inData[0], rearranger, exec);
+                m_data = exec.createColumnRearrangeTable(tableIn, rearranger, exec);
                 fac.closeImgOpener();
             } else if (colCreationMode.equals(ColCreationModes.REPLACE)) { // Replace
-                final ColumnRearranger rearranger = new ColumnRearranger(inData[0].getSpec());
-                final DataColumnSpec newColSpec = inData[0].getSpec().getColumnSpec(m_srcImgCol.getStringValue());
+                final ColumnRearranger rearranger = new ColumnRearranger(tableIn.getSpec());
+                final DataColumnSpec newColSpec = tableIn.getSpec().getColumnSpec(m_srcImgCol.getStringValue());
                 final IlastikCellFactory fac = createResultCellFactory(newColSpec);
                 rearranger.replace(fac, m_srcImgCol.getStringValue());
-                m_data = exec.createColumnRearrangeTable(inData[0], rearranger, exec);
+                m_data = exec.createColumnRearrangeTable(tableIn, rearranger, exec);
                 fac.closeImgOpener();
             } else {
                 throw new IllegalArgumentException("The value of the column creation setting is invalid!");
@@ -293,7 +314,7 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
 
             return new BufferedDataTable[]{m_data};
         } catch (final Exception e) {
-            KNIPGateway.log().error("Error when executing Ilastik.");
+            KNIPGateway.log().error("Error while executing Ilastik.", e);
 
             throw new IllegalStateException(e);
         } finally {
@@ -313,32 +334,66 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
      *
      * Read resulting images every channel is a probability map for one labeling
      *
+     * @param inData
+     *
      * @param exec
      *
      * @param exec
      * @param outFiles
      */
-    @SuppressWarnings("unchecked")
-    private void readResultImages(final ImgPlusCellFactory factory, final DataContainer container) {
+    private void readResultImages(final BufferedDataTable inData, final DataContainer container) {
 
         final ScifioImgSource imgOpener = new ScifioImgSource();
 
-        m_outFiles.forEach((final RowKey key, final Pair<String, String> pair) -> {
-            try {
-                DataCell[] cells = new DataCell[1];
+        //m_outFiles.forEach((final RowKey key, final Pair<String, String> pair) -> {
+        for (DataRow row : inData) {
 
-                ImgPlus<RealType> img = imgOpener.getImg(pair.getFirst(), 0);
-                img.setSource(pair.getSecond());
-                img.setName(key + "_result");
-                cells[0] = factory.createCell(img);
-                container.addRowToTable(new DefaultRow(key, cells));
+            try {
+                DataCell cell = readImageForRow(row, imgOpener);
+
+                DataCell[] cells = new DataCell[1];
+                cells[0] = cell;
+                container.addRowToTable(new DefaultRow(row.getKey(), cells));
             } catch (Exception e) {
-                imgOpener.close();
                 throw new IllegalStateException(
-                        "Can't read image in Ilastik Headless Node at RowId: " + key + " : " + e, e);
+                        "Can't read image in Ilastik Headless Node at RowId: " + row.getKey() + " : " + e, e);
+            } finally {
+                imgOpener.close();
             }
-        });
-        imgOpener.close();
+        }
+    }
+
+    /**
+     *
+     * @param row
+     * @param imgOpener
+     * @return DataCell of new Image read from location given by m_outFiles
+     * @throws Exception
+     */
+    private DataCell readImageForRow(final DataRow row, final ScifioImgSource imgOpener) throws Exception {
+
+        final DataCell cell_in = row.getCell(m_inputImgColIdx);
+
+        if (cell_in.isMissing()) {
+            return new MissingCell(null);
+        }
+
+        final ImgPlusValue<?> imgInValue = (ImgPlusValue<?>)cell_in;
+
+        final RowKey key = row.getKey();
+
+        final String path = m_outFiles.get(key);
+
+        final ImgPlus<T> img = (ImgPlus<T>)imgOpener.getImg(path, 0);
+        final ImgPlus<T> imgOut =
+                m_outputDimensionsOverride.getBooleanValue() ? overrideTimeDimension(img, imgInValue) : img;
+
+        final String source = imgInValue.getImgPlus().getSource();
+        imgOut.setSource(source);
+        imgOut.setName(key + "_result");
+        final DataCell cell = m_imgPlusCellFactory.createCell(imgOut);
+
+        return cell;
     }
 
     /**
@@ -405,12 +460,12 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
         redirectToKnimeConsole(p.getErrorStream(), DirectedLogServiceFactory.error());
 
         try {
-            while(! p.waitFor(500, TimeUnit.MILLISECONDS)) {
+            while (!p.waitFor(500, TimeUnit.MILLISECONDS)) {
                 exec.checkCanceled();
             }
         } catch (CanceledExecutionException cee) {
-           KNIPGateway.log().error("Execution canceled, closing Ilastik now.");
-           p.destroy();
+            KNIPGateway.log().error("Execution canceled, closing Ilastik now.");
+            p.destroy();
         }
 
         // 0 indicates successful execution
@@ -484,22 +539,23 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
      * @return SettingsModelString for max amount of memory (mb) for ilastik
      */
     public static SettingsModelInteger createIlastikMaxMemoryModel() {
-        return new SettingsModelInteger("ilastik_max_memory", (int) (Runtime.getRuntime().maxMemory() / 1024L / 1024L));
+        return new SettingsModelInteger("ilastik_max_memory", (int)(Runtime.getRuntime().maxMemory() / 1024L / 1024L));
     }
 
     /**
-    * @return SettingsModelString for ilastik thread count
-    */
-   public static SettingsModelIntegerBounded createIlastikThreadCountModel() {
-       return new SettingsModelIntegerBounded("ilastik_thread_count", KNIMEConstants.GLOBAL_THREAD_POOL.getMaxThreads(), 1, Integer.MAX_VALUE);
-   }
+     * @return SettingsModelString for ilastik thread count
+     */
+    public static SettingsModelIntegerBounded createIlastikThreadCountModel() {
+        return new SettingsModelIntegerBounded("ilastik_thread_count",
+                KNIMEConstants.GLOBAL_THREAD_POOL.getMaxThreads(), 1, Integer.MAX_VALUE);
+    }
 
-   /**
-   * @return SettingsModelString for source image column.
-   */
-  public static SettingsModelString createImgColModel() {
-      return new SettingsModelString("src_image", "");
-  }
+    /**
+     * @return SettingsModelString for source image column.
+     */
+    public static SettingsModelString createImgColModel() {
+        return new SettingsModelString("src_image", "");
+    }
 
     /**
      * @return {@link SettingsModelString} for the column creation mode.
@@ -507,6 +563,13 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
     public static SettingsModelString createColCreationModeModel() {
         return new SettingsModelString("colCreationMode", ColCreationModes.NEW_TABLE);
 
+    }
+
+    /**
+     * @return SettingsModelBoolean if XYT output dimensions from ilastik should be changed to XYZC
+     */
+    public static SettingsModelBoolean createOutputDimensionsOverrideModel() {
+        return new SettingsModelBoolean("output_dimensions_override", true);
     }
 
     /**
@@ -528,6 +591,7 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
         m_srcImgCol.validateSettings(settings);
         m_ilastikMaxMemory.validateSettings(settings);
         m_ilastikThreadCount.validateSettings(settings);
+        m_outputDimensionsOverride.validateSettings(settings);
 
         try {
             m_colCreationModeModel.validateSettings(settings);
@@ -550,6 +614,7 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
         m_srcImgCol.loadSettingsFrom(settings);
         m_ilastikMaxMemory.loadSettingsFrom(settings);
         m_ilastikThreadCount.loadSettingsFrom(settings);
+        m_outputDimensionsOverride.loadSettingsFrom(settings);
 
         try {
             m_colCreationModeModel.loadSettingsFrom(settings);
@@ -605,6 +670,55 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
 
     }
 
+    /**
+     * @param ilastikImg ilastik output image
+     * @param imgInValue ilastik input image as ImgPlusValue
+     * @return imgPlus ilastikImg split from XYT to XYZC
+     */
+    protected ImgPlus<T> overrideTimeDimension(final ImgPlus<T> ilastikImg, final ImgPlusValue<?> imgInValue) {
+        ImgPlus<T> imgOut;
+
+        List<RandomAccessibleInterval<T>> ztStack = new ArrayList<>();
+
+        int tIdx = ilastikImg.dimensionIndex(Axes.TIME);
+        long tSize = ilastikImg.dimension(tIdx);
+
+        final long[] imgInDims = imgInValue.getDimensions();
+        int zIdx = imgInValue.getMetadata().dimensionIndex(Axes.Z);
+
+        long zSize = imgInDims[zIdx];
+        long cSize = tSize / zSize;
+
+        for (int c = 0; c < cSize; c++) {
+
+            List<RandomAccessibleInterval<T>> zStack = new ArrayList<>();
+            for (int z = 0; z < zSize; z++) {
+                final IntervalView<T> hyperSlice = Views.hyperSlice(ilastikImg, tIdx, c + (z * cSize));
+                zStack.add(hyperSlice);
+            }
+
+            final RandomAccessibleInterval<T> zStackView = Views.stack(zStack);
+            ztStack.add(zStackView);
+        }
+        final RandomAccessibleInterval<T> ztStackView = Views.stack(ztStack);
+
+        Img<T> ztImg = ImgView.wrap(ztStackView, new ArrayImgFactory<T>());
+
+        CalibratedAxis[] imgInAxes = new CalibratedAxis[imgInDims.length];
+        imgInValue.getMetadata().axes(imgInAxes);
+
+        imgOut = new ImgPlus<T>(ztImg);
+
+        for (int d = 0; d < imgInAxes.length; d++) {
+            CalibratedAxis axis = imgInAxes[d];
+            imgOut.setAxis(axis, d);
+        }
+
+        imgOut.setAxis(new DefaultLinearAxis(Axes.CHANNEL), imgInAxes.length + 1);
+
+        return imgOut;
+    }
+
     class IlastikCellFactory extends SingleCellFactory {
         private ScifioImgSource imgOpener;
 
@@ -616,20 +730,13 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
             imgOpener = new ScifioImgSource();
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         // Get the scores weighted by the exploration factor
         public DataCell getCell(final DataRow row) {
-            RowKey key = row.getKey();
-            Pair<String, String> names = m_outFiles.get(key);
             DataCell cell;
             try {
-                String outfile = names.getFirst();
-                String source = names.getSecond();
-                final ImgPlus<T> img = (ImgPlus<T>)imgOpener.getImg(outfile, 0);
-                img.setSource(source);
-                img.setName(key + "_result");
-                cell = m_imgPlusCellFactory.createCell(img);
+                cell = readImageForRow(row, imgOpener);
+
             } catch (Exception e) {
                 throw new IllegalStateException("Error during execution: " + e, e);
             }
@@ -641,9 +748,9 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
         }
     }
 
-
     interface DirectedLogService {
         public void log(Object arg0);
+
         public void log(Object arg0, Throwable arg1);
     }
 

--- a/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
+++ b/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
@@ -282,14 +282,14 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
             } else {
                 throw new IllegalArgumentException("The value of the column creation setting is invalid!");
             }
-            cleanUp(tmpDir);
 
             return new BufferedDataTable[]{m_data};
         } catch (final Exception e) {
-            KNIPGateway.log()
-                    .error("Error when executing Ilastik. Please check the dimensionality of the input images.");
-            cleanUp(tmpDir);
+            KNIPGateway.log().error("Error when executing Ilastik.");
+
             throw new IllegalStateException(e);
+        } finally {
+            cleanUp(tmpDir);
         }
     }
 
@@ -413,7 +413,7 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
      * @param logService
      * @throws IOException
      */
-    static void redirectToKnimeConsole(final InputStream in, final DirectedLogService logger) {
+    static void redirectToKnimeConsole(final InputStream in, final DirectedLogService defaultLogger) {
 
         Thread t = new Thread() {
             @Override
@@ -423,7 +423,11 @@ public class IlastikHeadlessNodeModel<T extends RealType<T>> extends NodeModel i
 
                 try (BufferedReader bis = new BufferedReader(new InputStreamReader(in, Charset.defaultCharset()))) {
                     while ((line = bis.readLine()) != null) {
-                        logger.log(line);
+                        if (line.contains("WARNING")) {
+                            KNIPGateway.log().warn(line);
+                        } else {
+                            defaultLogger.log(line);
+                        }
                     }
                 } catch (IOException ioe) {
                     throw new RuntimeException("Could not read ilastik output", ioe);

--- a/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
+++ b/org.knime.knip.ilastik/src/org/knime/knip/ilastik/nodes/headless/IlastikHeadlessNodeModel.java
@@ -676,11 +676,18 @@ public class IlastikHeadlessNodeModel<T extends RealType<T> & NativeType<T>> ext
      * @return imgPlus ilastikImg split from XYT to XYZC
      */
     protected ImgPlus<T> overrideTimeDimension(final ImgPlus<T> ilastikImg, final ImgPlusValue<?> imgInValue) {
+
+        if (ilastikImg.dimensionIndex(Axes.CHANNEL) != -1) {
+            KNIPGateway.log().error("The ilastik output already has a Channel axis. Skipping override.");
+            return ilastikImg;
+        }
+
         ImgPlus<T> imgOut;
 
         List<RandomAccessibleInterval<T>> ztStack = new ArrayList<>();
 
         int tIdx = ilastikImg.dimensionIndex(Axes.TIME);
+
         long tSize = ilastikImg.dimension(tIdx);
 
         final long[] imgInDims = imgInValue.getDimensions();


### PR DESCRIPTION
ilastik gave me a XYT .tiff instead of a XYZC .tiff, so I implemented an override within knime.

missing input cells should be handled correctly by readResultImages().